### PR TITLE
Improve scraper logging

### DIFF
--- a/cmd/scraper/main.go
+++ b/cmd/scraper/main.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"fmt"
-	"log"
-	"nba-predictor/internal/scraper"
 	"os"
+
+	"nba-predictor/internal/logger"
+	"nba-predictor/internal/scraper"
+
+	"github.com/rs/zerolog/log"
 
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
@@ -12,15 +15,17 @@ import (
 
 // go run cmd/scraper/main.go game
 func main() {
+	logger.InitLogger(true)
+
 	if len(os.Args) < 2 {
-		log.Fatal("Usage: go run cmd/scraper/main.go [team|player|schedule|...]")
+		log.Fatal().Msg("Usage: go run cmd/scraper/main.go [team|player|schedule|...]")
 	}
 	cmd := os.Args[1]
 
 	dsn := "host=localhost user=postgres password=password dbname=nba_dev port=5432 sslmode=disable"
 	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
 	if err != nil {
-		log.Fatal("failed to connect database: ", err)
+		log.Fatal().Err(err).Msg("failed to connect database")
 	}
 
 	switch cmd {
@@ -31,6 +36,6 @@ func main() {
 	case "game":
 		scraper.ScrapeGameData(db)
 	default:
-		fmt.Println("No function matching")
+		log.Info().Msg("No function matching")
 	}
 }

--- a/internal/scraper/player.go
+++ b/internal/scraper/player.go
@@ -2,7 +2,6 @@ package scraper
 
 import (
 	"fmt"
-	"log"
 	"nba-predictor/internal/models"
 	"regexp"
 	"strconv"
@@ -10,16 +9,17 @@ import (
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
+	"github.com/rs/zerolog/log"
 	"gorm.io/gorm"
 )
 
 func ScrapePlayerData(db *gorm.DB) {
-	fmt.Println("Start scraping player data...")
+	log.Info().Msg("Start scraping player data")
 
 	var teams []models.Team
 	err := db.Find(&teams).Error
 	if err != nil {
-		log.Fatal("Failed to get teams:", err)
+		log.Fatal().Err(err).Msg("Failed to get teams")
 	}
 
 	teamIDs := []string{}
@@ -114,14 +114,14 @@ func ScrapePlayerData(db *gorm.DB) {
 
 			result := db.Create(&player)
 			if result.Error != nil {
-				log.Printf("Failed to insert %s: %v\n", name, result.Error)
+				log.Error().Err(result.Error).Str("name", name).Msg("Failed to insert player")
 			} else {
-				fmt.Println("Inserted:", name)
+				log.Info().Str("name", name).Msg("Inserted player")
 			}
 
 			count += 1
 		})
-		fmt.Println("End scraping player data... total data: ", count)
+		log.Info().Int("count", count).Msg("End scraping player data")
 
 	}
 	// ----------------------------------------------------------------------------------------

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -2,12 +2,12 @@ package scraper
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 	"strconv"
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
+	"github.com/rs/zerolog/log"
 )
 
 func getPageDoc(path string) *goquery.Document {
@@ -16,17 +16,17 @@ func getPageDoc(path string) *goquery.Document {
 	req.Header.Set("User-Agent", "Mozilla/5.0 (compatible)")
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal().Err(err).Msg("request failed")
 	}
 	defer res.Body.Close()
 
 	if res.StatusCode != 200 {
-		log.Fatalf("status code error: %d %s", res.StatusCode, res.Status)
+		log.Fatal().Int("code", res.StatusCode).Str("status", res.Status).Msg("status code error")
 	}
 
 	doc, err := goquery.NewDocumentFromReader(res.Body)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal().Err(err).Msg("failed to parse document")
 	}
 
 	return doc
@@ -35,7 +35,7 @@ func getPageDoc(path string) *goquery.Document {
 func stringToInt(s string) int {
 	i, err := strconv.Atoi(s)
 	if err != nil {
-		log.Printf("failed to convert '%s': %v", s, err)
+		log.Error().Err(err).Str("value", s).Msg("failed to convert")
 		return -1
 	}
 
@@ -45,7 +45,7 @@ func stringToInt(s string) int {
 func parseMadeAttempt(s string) (int, int) {
 	parts := strings.Split(s, "-")
 	if len(parts) != 2 {
-		log.Printf("unexpected made/attempt value: %q", s)
+		log.Error().Str("value", s).Msg("unexpected made/attempt value")
 		return 0, 0
 	}
 

--- a/internal/scraper/team.go
+++ b/internal/scraper/team.go
@@ -2,16 +2,16 @@ package scraper
 
 import (
 	"fmt"
-	"log"
 	"nba-predictor/internal/models"
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
+	"github.com/rs/zerolog/log"
 	"gorm.io/gorm"
 )
 
 func ScrapeTeamData(db *gorm.DB) {
-	fmt.Println("Start scraping team data...")
+	log.Info().Msg("Start scraping team data")
 
 	url := "https://www.espn.com/nba/teams"
 	doc := getPageDoc(url)
@@ -33,11 +33,11 @@ func ScrapeTeamData(db *gorm.DB) {
 
 		result := db.Create(&team)
 		if result.Error != nil {
-			log.Printf("Failed to insert %s: %v\n", teamName, result.Error)
+			log.Error().Err(result.Error).Str("team", teamName).Msg("Failed to insert")
 		} else {
-			fmt.Println("Inserted:", teamName)
+			log.Info().Str("team", teamName).Msg("Inserted team")
 		}
 	})
 
-	fmt.Println("End scraping team data...")
+	log.Info().Msg("End scraping team data")
 }


### PR DESCRIPTION
## Summary
- use zerolog for scraper logging
- add logger initialization to scraper CLI

## Testing
- `go vet ./...` *(fails: Forbidden - proxy.golang.org)*
- `go test ./...` *(fails: Forbidden - proxy.golang.org)*

------
https://chatgpt.com/codex/tasks/task_e_68845a6d056083219690bb1e74fe6281